### PR TITLE
ci: split CI workflows to separate PR & pushes

### DIFF
--- a/.github/workflows/pythonapp-push.yml
+++ b/.github/workflows/pythonapp-push.yml
@@ -1,0 +1,18 @@
+name: Python application Push
+
+on:
+  push:
+    branches:
+      - 'eol-release/*'
+
+jobs:
+  test:
+    uses: eol-uchile/workflow-commons/.github/workflows/pythonapp.yml@vastorga/fix-external-pr
+    with:
+      app_id: ${{ vars.EOLITO_BOT_APP_ID }}
+      django-lms: true
+      django-cms: false
+      platform-eol: false
+      platform-openuchile: false
+    secrets:
+      private_key: ${{ secrets.EOLITO_BOT_PRIVATE_KEY }}

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -1,9 +1,6 @@
-name: Python application
+name: Python application PRs
 
 on:
-  push:
-    branches:
-      - 'eol-release/*'
   pull_request_target:
     types:
       - opened


### PR DESCRIPTION
- to avoid environment auth ask on push