### PR TITLE
ci: pythonapp refactor to fix external checkout

### DIFF
--- a/.github/workflows/pythonapp-push.yml
+++ b/.github/workflows/pythonapp-push.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    uses: eol-uchile/workflow-commons/.github/workflows/pythonapp.yml@vastorga/fix-external-pr
+    uses: eol-uchile/workflow-commons/.github/workflows/pythonapp.yml@pythonapp-2
     with:
       app_id: ${{ vars.EOLITO_BOT_APP_ID }}
       django-lms: true

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -11,11 +11,8 @@ on:
 
 jobs:
   test:
-    uses: eol-uchile/workflow-commons/.github/workflows/pythonapp.yml@pythonapp-2
+    uses: eol-uchile/workflow-commons/.github/workflows/pythonapp_external.yml@pythonapp-2
     with:
       environment: external-pull-request
-      app_id: ${{ vars.EOLITO_BOT_APP_ID }}
       django-lms: true
       django-cms: false
-    secrets:
-      private_key: ${{ secrets.EOLITO_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
- Use new fix of pythonapp ci to allows external checkouts as unsafe code.
- Update pythonapp reference for push event case.