### PR TITLE
ci(lilac): simplify call & enable tests on push

### DIFF
--- a/.github/workflows/pythonapp-push.yml
+++ b/.github/workflows/pythonapp-push.yml
@@ -12,7 +12,5 @@ jobs:
       app_id: ${{ vars.EOLITO_BOT_APP_ID }}
       django-lms: true
       django-cms: false
-      platform-eol: false
-      platform-openuchile: false
     secrets:
       private_key: ${{ secrets.EOLITO_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
Simplify call for lilac & re-enable tests for push event, disabled in 335e0a0ab4795ed488a4998e110738482cde0e95 with the file split.